### PR TITLE
Replace routes modules with a simple, generic route handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,12 +62,12 @@ if (config.isDevelopment) {
 
 // -- Routes -------------------------------------------------------------------
 
-app.get('/',        routes.home);
-app.get('/base/',   routes.base);
-app.get('/grids/',  routes.grids);
-app.get('/forms/',  routes.forms);
-app.get('/tables/', routes.tables);
-app.get('/lists/',  routes.lists);
+app.get('/',        routes.render('home'));
+app.get('/base/',   routes.render('base'));
+app.get('/grids/',  routes.render('grids'));
+app.get('/forms/',  routes.render('forms'));
+app.get('/tables/', routes.render('tables'));
+app.get('/lists/',  routes.render('lists'));
 
 // -- Exports ------------------------------------------------------------------
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,11 +38,14 @@ exports.code = function (type, options) {
         type    = 'html';
     }
 
-    var content = Handlebars.Utils.escapeExpression(options.fn(this));
-    return '<pre class="snippet" data-language="' + type + '"><code>' + content.trim() + '</code></pre>';
+    var content = Handlebars.Utils.escapeExpression(options.fn(this)),
+        open    = '<pre class="snippet" data-language="' + type + '"><code>',
+        close   = '</code></pre>';
+
+    return open + content.trim() + close;
 };
 
-exports.activeNav = function (id) {
+exports.setActiveNav = function (id) {
     var nav = [];
 
     this.nav.forEach(function (item) {
@@ -60,4 +63,12 @@ exports.activeNav = function (id) {
     });
 
     this.nav = nav;
+};
+
+exports.setTitle = function (title) {
+    this.title = title;
+};
+
+exports.setSubTitle = function (subTitle) {
+    this.subTitle = subTitle;
 };

--- a/lib/routes/base.js
+++ b/lib/routes/base.js
@@ -1,6 +1,0 @@
-module.exports = function (req, res, next) {
-    res.render('base', {
-        title   : 'Normalize.css',
-        subTitle: 'A modern, HTML5-ready alternative to CSS resets'
-    });
-};

--- a/lib/routes/forms.js
+++ b/lib/routes/forms.js
@@ -1,6 +1,0 @@
-module.exports = function (req, res, next) {
-    res.render('forms', {
-        title   : 'YUI Forms CSS',
-        subTitle: 'Simple CSS for HTML Forms'
-    });
-};

--- a/lib/routes/grids.js
+++ b/lib/routes/grids.js
@@ -1,6 +1,0 @@
-module.exports = function (req, res, next) {
-    res.render('grids', {
-        title   : 'YUI Responsive Grids',
-        subTitle: 'A fully-customizable responsive grid'
-    });
-};

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -1,3 +1,0 @@
-module.exports = function (req, res) {
-    res.render('home');
-};

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,9 +1,9 @@
+function render(viewName) {
+    return function (req, res) {
+        res.render(viewName);
+    };
+}
+
 module.exports = {
-    base   : require('./base'),
-    forms  : require('./forms'),
-    grids  : require('./grids'),
-    home   : require('./home'),
-    layouts: require('./layouts'),
-    lists  : require('./lists'),
-    tables : require('./tables')
+    render: render
 };

--- a/lib/routes/layouts.js
+++ b/lib/routes/layouts.js
@@ -1,3 +1,0 @@
-module.exports = function (req, res) {
-    res.render('layouts');
-};

--- a/lib/routes/lists.js
+++ b/lib/routes/lists.js
@@ -1,6 +1,0 @@
-module.exports = function (req, res, next) {
-    res.render('lists', {
-        title   : 'YUI List CSS',
-        subTitle: 'Simple CSS for HTML Lists'
-    });
-};

--- a/lib/routes/tables.js
+++ b/lib/routes/tables.js
@@ -1,6 +1,0 @@
-module.exports = function (req, res, next) {
-    res.render('tables', {
-        title   : 'YUI Tables CSS',
-        subTitle: 'Simple CSS for HTML Tables'
-    });
-};

--- a/views/base.handlebars
+++ b/views/base.handlebars
@@ -1,6 +1,9 @@
+{{setTitle     "Normalize.css"}}
+{{setSubTitle  "A modern, HTML5-ready alternative to CSS resets"}}
+{{setActiveNav "base"}}
+
 {{addCdnCSS "3.9.0pr3" "cssnormalize"}}
-{{addGithubCSS "tilomitra" "csstables"   "master/css/tables.css"}}
-{{activeNav "base"}}
+{{addGithubCSS "tilomitra" "csstables" "master/css/tables.css"}}
 
 {{> header}}
 
@@ -33,7 +36,7 @@
     <h2 class="content-subhead">Typography</h2>
 
     <p>
-        To keep YUI CSS lean and extensible, we do not add any typographic styles over the foundational layer provided by Normalize. This means that you get headings with different sizes, blockquotes, lists, definition lists and more, but their styles are minimal and easy to over-ride. 
+        To keep YUI CSS lean and extensible, we do not add any typographic styles over the foundational layer provided by Normalize. This means that you get headings with different sizes, blockquotes, lists, definition lists and more, but their styles are minimal and easy to over-ride.
     </p>
 
     <h2>Headings</h2>
@@ -56,7 +59,7 @@
     <h2>Blockquotes</h2>
 
     <p>
-        Blockquotes encompass text that is meant to represent a quotation. By default, blockquotes look like regular text, except that they are indented. This gives you the freedom to set your own styles on top. Here's a default one: 
+        Blockquotes encompass text that is meant to represent a quotation. By default, blockquotes look like regular text, except that they are indented. This gives you the freedom to set your own styles on top. Here's a default one:
     </p>
 
     {{> base/blockquote}}
@@ -66,7 +69,7 @@
     {{/code}}
 
     <p>
-        Taking advantage of the lack of default styles, we've customized the blockquotes on this site to look a little different. We encourage you to do the same based on how your site looks. 
+        Taking advantage of the lack of default styles, we've customized the blockquotes on this site to look a little different. We encourage you to do the same based on how your site looks.
     </p>
 
     <blockquote class="content-quote">
@@ -102,7 +105,7 @@
     <h2>Inline Styles</h2>
 
     <p>
-        There are numerous other inline styles that can be used. Here's a quick list from the <a href="http://github.com/necolas/normalize.css">Normalize documentation</a>: 
+        There are numerous other inline styles that can be used. Here's a quick list from the <a href="http://github.com/necolas/normalize.css">Normalize documentation</a>:
     </p>
 
     {{> base/inline}}
@@ -116,5 +119,5 @@
     <p>
         We made a more opinionated look and feel for these elements, while keeping them minimal enough so that you can customize them for your site or app's needs. Check out our CSS for <a href="../forms/">Forms</a>, <a href="../tables/">Tables</a>, and <a href="../lists/">Navigation Lists</a>.
     </p>
-        
+
 </div>

--- a/views/error.handlebars
+++ b/views/error.handlebars
@@ -1,11 +1,15 @@
-<h1>{{status}}</h1>
+{{setTitle status}}
 
-<div class="error">
-    <p class="error-msg">
-      {{#if message}}
-        {{message}}
-      {{else}}
-        Looks like there was a problem :(
-      {{/if}}
-    </p>
+{{> header}}
+
+<div class="content">
+    <div class="error">
+        <p class="error-msg">
+          {{#if message}}
+            {{message}}
+          {{else}}
+            Looks like there was a problem :(
+          {{/if}}
+        </p>
+    </div>
 </div>

--- a/views/forms.handlebars
+++ b/views/forms.handlebars
@@ -1,7 +1,10 @@
+{{setTitle     "YUI Forms CSS"}}
+{{setSubTitle  "Simple CSS for HTML Forms"}}
+{{setActiveNav "forms"}}
+
+{{addCdnCSS "3.9.0pr3" "cssbutton"}}
 {{addGithubCSS "tilomitra" "cssforms" "master/css/forms.css"}}
 {{addGithubCSS "tilomitra" "cssforms" "master/css/forms-responsive.css"}}
-{{addCdnCSS "3.9.0pr3" "cssbutton"}}
-{{activeNav "forms"}}
 
 {{> header}}
 

--- a/views/grids.handlebars
+++ b/views/grids.handlebars
@@ -1,6 +1,9 @@
+{{setTitle     "YUI Responsive Grids"}}
+{{setSubTitle  "A fully-customizable responsive grid"}}
+{{setActiveNav "grids"}}
+
 {{addCdnCSS "3.9.0pr3" "cssgrids-responsive"}}
-{{addGithubCSS "tilomitra" "csstables"   "master/css/tables.css"}}
-{{activeNav "grids"}}
+{{addGithubCSS "tilomitra" "csstables" "master/css/tables.css"}}
 
 {{> header}}
 
@@ -46,7 +49,7 @@
 
     <h2 class="content-subhead">Grids on Mobile</h2>
 
-    <p>Putting the <code>yui3-g</code> classname on the wrapper instead of <code>yui3-g-r</code> will ensure that grid units will not collapse on small screens. This is a good way to make grids on smaller screens like phones. 
+    <p>Putting the <code>yui3-g</code> classname on the wrapper instead of <code>yui3-g-r</code> will ensure that grid units will not collapse on small screens. This is a good way to make grids on smaller screens like phones.
 
     {{> grids/mobile-col}}
 

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -1,11 +1,12 @@
-{{addCdnCSS "gallery-2013.02.13-21-08" "gallerycss-cssform"}}
+{{setTitle     "YUI CSS"}}
+{{setSubTitle  "Simple CSS for the web."}}
+{{setActiveNav "home"}}
+
 {{addLocalCSS "/css/home.css"}}
 
-{{activeNav "home"}}
-
 <div class="hero">
-    <h1 class="yui3-u-1">YUI CSS</h1>
-    <h2 class="yui3-u-1">Simple CSS for the web.</h2>
+    <h1 class="yui3-u-1">{{title}}</h1>
+    <h2 class="yui3-u-1">{{subTitle}}</h2>
 </div>
 
 

--- a/views/lists.handlebars
+++ b/views/lists.handlebars
@@ -1,14 +1,15 @@
-<!-- adding to the top so that the dropdown example code can run -->
-<script src="http://yui.yahooapis.com/3.9.0pr2/build/yui/yui-min.js"></script>
+{{setTitle     "YUI List CSS"}}
+{{setSubTitle  "Simple CSS for HTML Lists"}}
+{{setActiveNav "lists"}}
 
-{{addGithubCSS "tilomitra" "csslist" "master/css/list-paginator.css"}}
 {{addCdnCSS "3.9.0pr3" "cssbutton"}}
+{{addGithubCSS "tilomitra" "csslist" "master/css/list-paginator.css"}}
 {{addLocalCSS "/css/lists.css"}}
-
-{{activeNav "lists"}}
 
 {{> header}}
 
+<!-- adding to the top so that the dropdown example code can run -->
+<script src="http://yui.yahooapis.com/3.9.0pr3/build/yui/yui-min.js"></script>
 
 <div class="content">
 
@@ -68,7 +69,7 @@
 
     <h3>Dark Menu</h3>
     <p>
-        Light menus don't work well with dark backgrounds. Make your menu darker by adding the class <code>yui3-menu-dark</code>. 
+        Light menus don't work well with dark backgrounds. Make your menu darker by adding the class <code>yui3-menu-dark</code>.
     </p>
 
     <div class="dark-ribbon">
@@ -82,7 +83,7 @@
 
     <h2 class="content-subhead">Paginators</h2>
     <p>
-        Paginators are list-based elements too! You can implement a paginator control by adding the <code>.yui3-paginator</code> classname to a <code>ul</code> element. Paginator controls generally look like buttons, but omit the <code>yui3-button</code> class name if you want simple paginators. 
+        Paginators are list-based elements too! You can implement a paginator control by adding the <code>.yui3-paginator</code> classname to a <code>ul</code> element. Paginator controls generally look like buttons, but omit the <code>yui3-button</code> class name if you want simple paginators.
     </p>
 
     {{> lists/paginator}}

--- a/views/partials/header.handlebars
+++ b/views/partials/header.handlebars
@@ -1,6 +1,9 @@
 <div class="header yui3-u-1">
 
     <h1 class="yui3-u-1">{{title}}</h1>
+
+  {{#if subTitle}}
     <h2 class="yui3-u">{{subTitle}}</h2>
+  {{/if}}
 
 </div>

--- a/views/tables.handlebars
+++ b/views/tables.handlebars
@@ -1,5 +1,8 @@
-{{addGithubCSS "tilomitra" "csstables"   "master/css/tables.css"}}
-{{activeNav "tables"}}
+{{setTitle     "YUI Tables CSS"}}
+{{setSubTitle  "Simple CSS for HTML Tables"}}
+{{setActiveNav "tables"}}
+
+{{addGithubCSS "tilomitra" "csstables" "master/css/tables.css"}}
 
 {{> header}}
 


### PR DESCRIPTION
This replaces the need to create a route handle just to render out a view by name. Two new helpers were added: `{{setTitle "Title"}}` and `{{setSubTitle "Sub title"}}`; this allows these values to be set in the Handlebars view.
