### PR TITLE
add skinbuilder link to menu

### DIFF
--- a/views/partials/menu.handlebars
+++ b/views/partials/menu.handlebars
@@ -14,6 +14,10 @@
           {{/each}}
 
           <li class="menu-item-yui">
+              <a href="http://yui.github.com/skinbuilder/">Skin Builder</a>
+          </li>
+
+          <li>
               <a href="http://yuilibrary.com/">YUI Library</a>
           </li>
         </ul>


### PR DESCRIPTION
We should have the Skinbuilder as a menu link until we integrate it into the site as a v2. I think @jenny wanted this by tomorrow for her meeting with Thierry, so it would be nice to pull this in. 

I added this with a `menu-item-yui` class, since it's an external link just like YUI Library. I felt it was best to group the external links together. 
