### PR TITLE
Ghh fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "combohandler"       : "0.2.x",
         "express"            : "3.x",
         "express3-handlebars": "0.4.x",
-        "express-state"      : "0.0.x",
+        "express-state"      : "0.0.2",
         "handlebars"         : "1.x"
     },
 


### PR DESCRIPTION
We don't need the `0.0.2` explicitly, but we do need `server.js` in the package.json for the site to run properly on Manhattan. 
