### PR TITLE
Add Extend documentation + routes

### DIFF
--- a/public/css/bootstrap/modal.css
+++ b/public/css/bootstrap/modal.css
@@ -1,3 +1,13 @@
+/*!
+ * Bootstrap v2.3.2
+ *
+ * Copyright 2012 Twitter, Inc
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ */
+
 .modal-backdrop {
   position: fixed;
   top: 0;

--- a/views/partials/extend/modal.handlebars
+++ b/views/partials/extend/modal.handlebars
@@ -6,6 +6,15 @@
 </p>
 
 <!-- Modal -->
+<!--
+ * Bootstrap v2.3.2
+ *
+ * Copyright 2012 Twitter, Inc
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Designed and built with all the love in the world @twitter by @mdo and @fat.
+ -->
 <div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-header">
         <h1 id="myModalLabel">A Bootstrap Modal with Pure</h1>


### PR DESCRIPTION
This may be a slightly controversial pull request, but one that I think will be useful to end users. This pull request adds an **"Extend"** page to the Pure site. 

Here's what that means:
- The Extend page outlines how to build on top of Pure. This is something that @msweeney and I talked about a few weeks ago. This is different from **Customize**, which outlines how someone can tweak Pure. 
- The Extend page provides us an outlet to describe our CSS Style Guide (which I have included). It briefly introduces the concept of SMACSS, and outlines our CSS conventions going forward. This will be useful to us and developers.
### Possible Controversial Areas :smile:
- The page also gives us a space to list out some third-party contributions. I think doing that here, below where I explain how to build on top of Pure, is completely natural. I would like to track how many users click on these links to see if it's worthwhile to highlight this section more.
- I've included an example on the Extend page on how to use Bootstrap and jQuery with Pure. The market for those two products is huge, and we stand to gain more by showcasing how Pure complements them, rather by telling people to ditch them totally. I could also have a YUI example if you feel that's something that would help drive more customers.

Let me know what you guys think.

//cc @jenny @jconniff 
