### PR TITLE
Fixing address on base page

### DIFF
--- a/views/partials/base/address.handlebars
+++ b/views/partials/base/address.handlebars
@@ -1,6 +1,5 @@
 <address>
-    <strong>Yahoo</strong><br>
-    701 First Ave.<br>
-    Sunnyvale, CA<br>
-    94089
+    <a href="http://github.com/tilomitra">Tilo Mitra</a><br>
+    <a href="http://github.com/ericf">Eric Ferraiuolo</a><br>
+    <a href="http://github.com/rashadrussell">Rashad Russell</a><br>
 </address>


### PR DESCRIPTION
Fixing address on base page to follow good coding conventions when using the <address> element.
