### PR TITLE
Be smarter about Pure file sizes, how they're calculated and outputted

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,9 @@ app.locals({
 
     min: config.isProduction ? '-min' : '',
 
+    modules  : config.pure.modules,
+    filesizes: config.pure.filesizes,
+
     ga     : config.isProduction && config.ga,
     typekit: config.typekit
 });

--- a/config/filesizes.json
+++ b/config/filesizes.json
@@ -1,0 +1,1 @@
+{"base-context":1217,"base":1236,"buttons-core":302,"buttons":847,"forms-core":615,"forms":1750,"grids-core":284,"forms-nr":1636,"grids":699,"grids-nr":544,"grids-units":484,"menus-core":708,"menus":1129,"menus-paginator":362,"menus-nr":1096,"tables":574,"pure":4328,"pure-nr":4071}

--- a/config/pure.js
+++ b/config/pure.js
@@ -4,7 +4,9 @@ var path  = require('path'),
     isProduction = process.env.NODE_ENV === 'production',
     isPureLocal, bowerrc, bower;
 
-exports.version = '0.2.0';
+exports.version   = '0.2.0';
+exports.filesizes = require('./filesizes');
+exports.modules   = ['base', 'grids', 'forms', 'buttons', 'tables', 'menus'];
 
 // We always want to serve from the CDN in production.
 if (isProduction) { return; }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -194,3 +194,20 @@ exports.setTitle = function (title) {
 exports.setSubTitle = function (subTitle) {
     this.subTitle = subTitle;
 };
+
+exports.fileSize = function (module, decimals) {
+    typeof decimals === 'number' || (decimals = 1);
+    var filesize = (this.filesizes[module] / 1024);
+    return filesize.toFixed(decimals) + 'KB';
+};
+
+exports.filePercent = function (module) {
+    var filesizes = this.filesizes,
+        total     = 0;
+
+    total = this.modules.reduce(function (size, module) {
+        return size + filesizes[module];
+    }, total);
+
+    return (filesizes[module] / total * 100).toFixed(4) + '%';
+};

--- a/scripts/filesizes.js
+++ b/scripts/filesizes.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+var path = require('path'),
+    fs   = require('fs'),
+    zlib = require('zlib'),
+
+    bowerrc   = JSON.parse(fs.readFileSync('.bowerrc', 'utf8')),
+    pureDir   = path.resolve(bowerrc.directory, 'pure', 'build'),
+    output    = path.resolve('./config/filesizes.json'),
+    filesizes = {},
+
+    modules, pending;
+
+modules = fs.readdirSync(pureDir).filter(function (filename) {
+    return (/\-min\.css$/).test(filename);
+}).map(function (filename) {
+    return filename.replace(/\-min\.css$/, '');
+});
+
+pending = modules.length;
+
+console.log('Reading in Pure files from:', pureDir);
+modules.forEach(function (module) {
+    var file = fs.readFileSync(path.join(pureDir, module + '-min.css'));
+
+    zlib.gzip(file, function (err, compressed) {
+        if (err) { throw err; }
+        filesizes[module] = compressed.length;
+        done();
+    });
+});
+
+function done() {
+    pending--;
+    if (pending) { return; }
+
+    fs.writeFileSync(output, JSON.stringify(filesizes));
+    console.log('Wrote Pure file sizes to:', output);
+}

--- a/views/pages/customize.handlebars
+++ b/views/pages/customize.handlebars
@@ -23,12 +23,12 @@
             <tr>
                 <td>Responsive Rollup</td>
                 <td>http://yui.yahooapis.com/pure/{{pure_version}}/pure-min.css</td>
-                <td>4.2KB</td>
+                <td>{{fileSize "pure"}}</td>
             </tr>
             <tr>
                 <td>Non-Responsive Rollup</td>
                 <td>http://yui.yahooapis.com/pure/{{pure_version}}/pure-nr-min.css</td>
-                <td>4.0KB</td>
+                <td>{{fileSize "pure-nr"}}</td>
             </tr>
         </tbody>
     </table>

--- a/views/pages/home.handlebars
+++ b/views/pages/home.handlebars
@@ -23,34 +23,34 @@
 <div class="pure-g-r marketing-ribbon">
     <div class="pure-u-1">
         <div class="size-chart l-vbox pure-g">
-            <div class="size-chart-item size-chart-base pure-u" style="width: 19%;">
+            <div class="size-chart-item size-chart-base pure-u" style="width: {{filePercent 'base'}};">
                 <a class="size-chart-label" href="{{pages.base}}">
-                    Base <span class="size-chart-size">1.2KB</span>
+                    Base <span class="size-chart-size">{{fileSize "base"}}</span>
                 </a>
             </div>
-            <div class="size-chart-item size-chart-grids pure-u" style="width: 11%;">
+            <div class="size-chart-item size-chart-grids pure-u" style="width: {{filePercent 'grids'}};">
                 <a class="size-chart-label" href="{{pages.grids}}">
-                    Grids <span class="size-chart-size">0.7KB</span>
+                    Grids <span class="size-chart-size">{{fileSize "grids"}}</span>
                 </a>
             </div>
-            <div class="size-chart-item size-chart-forms pure-u" style="width: 28.5%;">
+            <div class="size-chart-item size-chart-forms pure-u" style="width: {{filePercent 'forms'}};">
                 <a class="size-chart-label" href="{{pages.forms}}">
-                    Forms <span class="size-chart-size">1.8KB</span>
+                    Forms <span class="size-chart-size">{{fileSize "forms"}}</span>
                 </a>
             </div>
-            <div class="size-chart-item size-chart-buttons pure-u" style="width: 14.5%;">
+            <div class="size-chart-item size-chart-buttons pure-u" style="width: {{filePercent 'buttons'}};">
                 <a class="size-chart-label" href="{{pages.buttons}}">
-                    Buttons <span class="size-chart-size">0.9KB</span>
+                    Buttons <span class="size-chart-size">{{fileSize "buttons"}}</span>
                 </a>
             </div>
-            <div class="size-chart-item size-chart-tables pure-u" style="width: 9.5%;">
+            <div class="size-chart-item size-chart-tables pure-u" style="width: {{filePercent 'tables'}};">
                 <a class="size-chart-label" href="{{pages.tables}}">
-                    Tables <span class="size-chart-size">0.6KB</span>
+                    Tables <span class="size-chart-size">{{fileSize "tables"}}</span>
                 </a>
             </div>
-            <div class="size-chart-item size-chart-menus pure-u" style="width: 17.5%;">
+            <div class="size-chart-item size-chart-menus pure-u" style="width: {{filePercent 'menus'}};">
                 <a class="size-chart-label" href="{{pages.menus}}">
-                    Menus <span class="size-chart-size">1.1KB</span>
+                    Menus <span class="size-chart-size">{{fileSize "menus"}}</span>
                 </a>
             </div>
         </div>
@@ -58,7 +58,7 @@
         <div class="l-box">
             <h3>CSS with a minimal footprint.</h3>
             <p>
-                Pure is ridiculously tiny. The entire set of modules clocks in at <strong>4.2KB* minified and gzipped</strong>, without forgoing responsive styles, design, or ease of use. Crafted with mobile devices in mind, it was important to us to keep our file sizes small, and every line of CSS was carefully considered. If you decide to only use a subset of these modules, you'll save even more bytes.
+                Pure is ridiculously tiny. The entire set of modules clocks in at <b>{{fileSize "pure"}}* minified and gzipped</b>, without forgoing responsive styles, design, or ease of use. Crafted with mobile devices in mind, it was important to us to keep our file sizes small, and every line of CSS was carefully considered. If you decide to only use a subset of these modules, you'll save even more bytes.
             </p>
 
             <p style="font-size:small;">


### PR DESCRIPTION
This makes it _much_ easier to generate Pure's file sizes and use those via Handlebars helpers to output those on the site's web pages.

Closes #127

This is used by doing the following:

``` shell
$ bower install pure
$ ./scripts/filesizes.js
```

This will write a JSON file to: `config/filesizes.json`.
