### PR TITLE
Fix mistaken herf on a link to "Grids" page.

### DIFF
--- a/views/pages/forms.handlebars
+++ b/views/pages/forms.handlebars
@@ -76,7 +76,7 @@
 
     <h2 class="content-subhead">Input Sizing</h2>
     <p>
-        Input elements have fluid width sizes in a syntax that is similar to <a href="{{pages.home}}">Pure Grids</a>. You can apply a {{code "pure-input-*"}} class to these elements.
+        Input elements have fluid width sizes in a syntax that is similar to <a href="{{pages.grids}}">Pure Grids</a>. You can apply a {{code "pure-input-*"}} class to these elements.
     </p>
 
   {{#prefixIds "input-size"}}


### PR DESCRIPTION
Fix `herf` on a link to "home" which should be to "grids".
