### PR TITLE
Remove "Built on Pure" section from the Extend page

### DIFF
--- a/views/pages/extend.handlebars
+++ b/views/pages/extend.handlebars
@@ -99,21 +99,6 @@ for the stacked effect.
     </p>
 
 
-    {{sectionHeading "Built on Pure"}}
-
-    <p>
-        The following third-party modules are built on Pure.
-    </p>
-
-    <dl>
-        <dt><a href="http://tilomitra.github.io/csstypography/">Typography</a></dt>
-        <dd>Simple styling for web typography</dd>
-
-        <dt><a href="http://tilomitra.github.io/cssextras/">Extras</a></dt>
-        <dd>Simple styling for images, thumbnails, badges, contextual menus and alerts</dd>
-    </dl>
-
-
     {{sectionHeading "Pure + Bootstrap + JavaScript"}}
 
     <p>


### PR DESCRIPTION
These modules are not really built on Pure and it seems better to remove the reference from them now until the Bower enhancements land and we use that to extend Pure.

Closes #125
