### PR TITLE
Handle Pure served locally from the `pure` or `pure-release` repos

### DIFF
--- a/config/pure.js
+++ b/config/pure.js
@@ -2,7 +2,7 @@ var path  = require('path'),
     fs    = require('fs'),
 
     isProduction = process.env.NODE_ENV === 'production',
-    isPureLocal, bowerrc, bower;
+    isPureLocal, bowerrc, bower, localPure;
 
 exports.version   = '0.3.0';
 exports.filesizes = require('./filesizes');
@@ -17,12 +17,16 @@ isPureLocal = process.argv.slice(2).some(function (arg) {
 
 // Export the path at which to serve Pure from the locally-linked Bower package.
 if (isPureLocal) {
-    bowerrc = path.join(process.cwd(), '.bowerrc');
-    bower   = JSON.parse(fs.readFileSync(bowerrc));
+    bowerrc   = path.join(process.cwd(), '.bowerrc');
+    bower     = JSON.parse(fs.readFileSync(bowerrc));
+    localPure = path.join(process.cwd(), bower.directory, 'pure');
 
-    exports.local = path.join(process.cwd(), bower.directory, 'pure', 'build');
-
-    if (!fs.existsSync(exports.local)) {
+    // Handle `pure` and `pure-release` repo structures.
+    if (fs.existsSync(path.join(localPure, 'pure.css'))) {
+        exports.local = localPure;
+    } else if (fs.existsSync(path.join(localPure, 'build', 'pure.css'))) {
+        exports.local = path.join(localPure, 'build');
+    } else {
         console.warn('Your setup to serve Pure locally is wrong!');
     }
 }


### PR DESCRIPTION
This makes serving Pure locally when developing the website more robust now that the Bower package points to the `pure-release` repo.
