### PR TITLE
Fix #176: Replace `.pure-menu-link` with `.menu-link` globally

### DIFF
--- a/public/css/layouts/side-menu.css
+++ b/public/css/layouts/side-menu.css
@@ -7,7 +7,7 @@ Add transition to containers so they can push in and out.
 */
 #layout,
 #menu,
-.pure-menu-link {
+.menu-link {
     -webkit-transition: all 0.2s ease-out;
     -moz-transition: all 0.2s ease-out;
     -ms-transition: all 0.2s ease-out;
@@ -142,10 +142,10 @@ how it works:
 */
 
 /*
-`.pure-menu-link` represents the responsive menu toggle that shows/hides on
+`.menu-link` represents the responsive menu toggle that shows/hides on
 small screens.
 */
-.pure-menu-link {
+.menu-link {
     display: none; /* show this only on small screens */
     top: 0;
     left: 150px; /* `#menu`'s width */
@@ -157,32 +157,32 @@ small screens.
     padding: 2.2em 1.6em;
 }
 
-    .pure-menu-link:hover,
-    .pure-menu-link:focus {
+    .menu-link:hover,
+    .menu-link:focus {
         background: #000;
     }
 
-    .pure-menu-link span {
+    .menu-link span {
         position: relative;
         display: block;
     }
 
-    .pure-menu-link span,
-    .pure-menu-link span:before,
-    .pure-menu-link span:after {
+    .menu-link span,
+    .menu-link span:before,
+    .menu-link span:after {
         background-color: #fff;
         width: 100%;
         height: 0.2em;
     }
 
-        .pure-menu-link span:before,
-        .pure-menu-link span:after {
+        .menu-link span:before,
+        .menu-link span:after {
             position: absolute;
             margin-top: -0.6em;
             content: " ";
         }
 
-        .pure-menu-link span:after {
+        .menu-link span:after {
             margin-top: 0.6em;
         }
 
@@ -218,13 +218,13 @@ Hides the menu at `767px`, but modify this based on your app's needs.
         left: 0;
     }
 
-    .pure-menu-link {
+    .menu-link {
         position: fixed;
         left: 0;
         display: block; /* show the button on small screens */
     }
 
-    #layout.active .pure-menu-link {
+    #layout.active .menu-link {
         left: 150px;
     }
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -12,7 +12,7 @@ body,
 /* Add transition to containers so they can push in and out */
 #layout,
 #menu,
-.pure-menu-link {
+.menu-link {
     -webkit-transition: all 0.2s ease-out;
     -moz-transition: all 0.2s ease-out;
     -ms-transition: all 0.2s ease-out;
@@ -251,7 +251,7 @@ aside {
             background: #333;
         }
 
-    .pure-menu-link {
+    .menu-link {
         display: none; /* show this only on small screens */
         top: 0;
         left: 150px; /* "#menu width" */
@@ -264,19 +264,19 @@ aside {
         padding: 2.1em 1.6em;
     }
 
-        .pure-menu-link:hover,
-        .pure-menu-link:focus {
+        .menu-link:hover,
+        .menu-link:focus {
             background: #000;
         }
 
-        .pure-menu-link span {
+        .menu-link span {
             position: relative;
             display: block;
         }
 
-        .pure-menu-link span,
-        .pure-menu-link span:before,
-        .pure-menu-link span:after {
+        .menu-link span,
+        .menu-link span:before,
+        .menu-link span:after {
             background-color: #fff;
             width: 100%;
             height: .2em;
@@ -287,22 +287,22 @@ aside {
                     transition: all 0.4s;
         }
 
-            .pure-menu-link span:before,
-            .pure-menu-link span:after {
+            .menu-link span:before,
+            .menu-link span:after {
                 position: absolute;
                 margin-top: -.6em;
                 content: " ";
             }
 
-            .pure-menu-link span:after {
+            .menu-link span:after {
                 margin-top: .6em;
             }
 
-        .pure-menu-link.active span {
+        .menu-link.active span {
             background: transparent;
         }
 
-            .pure-menu-link.active span:before {
+            .menu-link.active span:before {
                 -webkit-transform: rotate(45deg) translate(.5em, .4em);
                    -moz-transform: rotate(45deg) translate(.5em, .4em);
                     -ms-transform: rotate(45deg) translate(.5em, .4em);
@@ -310,7 +310,7 @@ aside {
                         transform: rotate(45deg) translate(.5em, .4em);
             }
 
-            .pure-menu-link.active span:after {
+            .menu-link.active span:after {
                 -webkit-transform: rotate(-45deg) translate(.45em, -.35em);
                    -moz-transform: rotate(-45deg) translate(.45em, -.35em);
                     -ms-transform: rotate(-45deg) translate(.45em, -.35em);
@@ -395,13 +395,13 @@ a.pure-button-primary {
         left: 0;
     }
 
-    .pure-menu-link {
+    .menu-link {
         position: fixed;
         left: 0;
         display: block;
     }
 
-    #layout.active .pure-menu-link {
+    #layout.active .menu-link {
         left: 150px;
     }
 }

--- a/views/pages/layouts/examples/side-menu.handlebars
+++ b/views/pages/layouts/examples/side-menu.handlebars
@@ -5,7 +5,7 @@
 
 <div id="layout">
     <!-- Menu toggle -->
-    <a href="#menu" id="menuLink" class="pure-menu-link">
+    <a href="#menu" id="menuLink" class="menu-link">
         <!-- Hamburger icon -->
         <span></span>
     </a>

--- a/views/partials/menu.handlebars
+++ b/views/partials/menu.handlebars
@@ -1,4 +1,4 @@
-<a href="#menu" id="menuLink" class="pure-menu-link">
+<a href="#menu" id="menuLink" class="menu-link">
     <span></span>
 </a>
 


### PR DESCRIPTION
I changed the class names around so that people don't get the idea that `.pure-menu-link` is a class that is included in Pure. Fixes [#176](https://github.com/yui/pure-site/issues/176). 
