### PR TITLE
Simplification of `compareWidths`.

### DIFF
--- a/lib/pure/gridunits.js
+++ b/lib/pure/gridunits.js
@@ -69,13 +69,7 @@ function compareWidths(a, b) {
     a[1] || (a[1] = 1);
     b[1] || (b[1] = 1);
 
-    if ((a[0] / a[1]) < (b[0] / b[1])) { return -1; }
-    if ((a[0] / a[1]) > (b[0] / b[1])) { return 1; }
-
-    if (a[1] < b[1]) { return -1; }
-    if (a[1] > b[1]) { return 1; }
-
-    return 0;
+    return (a[0] * b[1]) - (a[1] * b[0]);
 }
 
 function isReducedFraction(numerator, denominator) {


### PR DESCRIPTION
Cross multiplying both fractions results in the two numerators you would've gotten if you expressed both fractions with their common denominators. 
