### PR TITLE
typo in "Using Grids with Your Font-Family"

### DIFF
--- a/views/pages/grids.handlebars
+++ b/views/pages/grids.handlebars
@@ -188,7 +188,7 @@
     {{sectionHeading "Using Grids with Your Font-Family" id="using-grids-with-custom-fonts" }}
 
     <p>
-        Pure Grids use a specific font stack to ensure the greatest OS/browser compatibility, and by default grid units will have {{code "font-family: sans-serif;"}} applied — this is the default font stack Pure's Base (Normalize.css) applies to the {{code "<body>"}}. Fortunately, it's quite easy to make sure your {{code "font-family"}} also applies to content within Pure Girds. Instead of applying your {{code "font-family"}} to only the {{code "<body>"}} element, apply it to the grid units as well:
+        Pure Grids use a specific font stack to ensure the greatest OS/browser compatibility, and by default grid units will have {{code "font-family: sans-serif;"}} applied — this is the default font stack Pure's Base (Normalize.css) applies to the {{code "<body>"}}. Fortunately, it's quite easy to make sure your {{code "font-family"}} also applies to content within Pure Grids. Instead of applying your {{code "font-family"}} to only the {{code "<body>"}} element, apply it to the grid units as well:
     </p>
 
     {{#code}}


### PR DESCRIPTION
"applies to content within Pure Girds" is now:
"applies to content within Pure Grids"
