### PR TITLE
Use ypromise instead of es6-promise

### DIFF
--- a/lib/pure/filesizes.js
+++ b/lib/pure/filesizes.js
@@ -2,7 +2,7 @@
 
 var fs      = require('fs'),
     path    = require('path'),
-    Promise = require('es6-promise').Promise,
+    Promise = require('ypromise'),
     zlib    = require('zlib');
 
 var utils = require('../utils');

--- a/lib/pure/gridunits.js
+++ b/lib/pure/gridunits.js
@@ -3,7 +3,7 @@
 var fs       = require('fs'),
     path     = require('path'),
     parseCSS = require('css-parse'),
-    Promise  = require('es6-promise').Promise;
+    Promise  = require('ypromise');
 
 var utils = require('../utils');
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "archiver": "~0.5.1",
         "bower": "~1.2.7",
         "css-parse": "~1.7.0",
-        "es6-promise": "~0.1.0",
+        "ypromise": "~0.2.2",
         "rework": "~0.20.2",
         "rework-pure-grids": "~0.3.3"
     },


### PR DESCRIPTION
Just to do some dogfooding.

Next version of `ypromise` will use `asap` in the server, so we can get some metrics on its performance benefits.
