### PR TITLE
Remove duplicate class in button documentation

### DIFF
--- a/views/partials/buttons/sizes.handlebars
+++ b/views/partials/buttons/sizes.handlebars
@@ -21,7 +21,7 @@
 
     <button class="button-xsmall pure-button">Extra Small Button</button>
     <button class="button-small pure-button">Small Button</button>
-    <button class="pure-button pure-button">Regular Button</button>
+    <button class="pure-button">Regular Button</button>
     <button class="button-large pure-button">Large Button</button>
     <button class="button-xlarge pure-button">Extra Large Button</button>
 </div>


### PR DESCRIPTION
The pure-button class is applied twice on a regular button in the sizes.handlebars partial.
