### PR TITLE
Fix use of duplicate input ids in form.

### DIFF
--- a/views/pages/layouts/examples/marketing.handlebars
+++ b/views/pages/layouts/examples/marketing.handlebars
@@ -103,8 +103,8 @@
                 <form class="pure-form pure-form-stacked">
                     <fieldset>
 
-                        <label for="email">Your Name</label>
-                        <input id="email" type="text" placeholder="Your Name">
+                        <label for="name">Your Name</label>
+                        <input id="name" type="text" placeholder="Your Name">
 
 
                         <label for="email">Your Email</label>


### PR DESCRIPTION
The form field for "Your name" had inadequate id / for attributes probably due to a copy and paste of the "email" field. 
