### PR TITLE
Update Start Kit on input `valuechange`

### DIFF
--- a/config/yui.js
+++ b/config/yui.js
@@ -39,7 +39,8 @@ exports.modules = {
         path: 'js/views/grid-input-view.js',
         requires: [
             'grid-tab-view',
-            'event-focus'
+            'event-focus',
+            'event-valuechange'
         ]
     },
 


### PR DESCRIPTION
Not sure if we actually want to go with this change as it might be too laggy. If decide that the standard on `change`/`blur` is a better experience, then we can remove "real-time" verbage.

Closes #256
