### PR TITLE
s/grid_units/pure_grids

### DIFF
--- a/views/pages/tools.handlebars
+++ b/views/pages/tools.handlebars
@@ -61,12 +61,12 @@
   {{/code}}
 
     <p>
-        Finally, add the necessary configuration through the {{code "grid_units"}} task. To see a full list of all configurable properties, check out the <a href="https://www.npmjs.org/package/grunt-pure-grids#readme">README documentation</a>.
+        Finally, add the necessary configuration through the {{code "pure_grids"}} task. To see a full list of all configurable properties, check out the <a href="https://www.npmjs.org/package/grunt-pure-grids#readme">README documentation</a>.
     </p>
 
 {{#code "js"}}
 grunt.initConfig({
-    grid_units: {
+    pure_grids: {
         dest : 'build/public/css/main-grid.css',
 
         options: {


### PR DESCRIPTION
'grid_units' task name will cause grunt to throw an error as it should be 'pure-grids' as per npm docs.
