### PR TITLE
Add a warning in the core section about using the hidden attribute

### DIFF
--- a/views/pages/base.handlebars
+++ b/views/pages/base.handlebars
@@ -42,6 +42,12 @@
     <input type="text" name="_csrf" hidden>
     {{/code}}
 
+
+    <h3>Hiding Elements in Legacy Browsers</h3>
+    <p>
+        If you need to toggle an HTML element's display using JavaScript, and want to fully support Internet Explorer 7 & 8, we suggest creating your own {{code ".hidden"}} CSS class instead of using the {{code "hidden"}} attribute.
+    </p>
+
     <h3>Responsive Images</h3>
 
     <p>

--- a/views/pages/base.handlebars
+++ b/views/pages/base.handlebars
@@ -45,7 +45,7 @@
 
     <h3>Hiding Elements in Legacy Browsers</h3>
     <p>
-        If you need to toggle an HTML element's display using JavaScript, and want to fully support Internet Explorer 7 & 8, we suggest creating your own {{code ".hidden"}} CSS class instead of using the {{code "hidden"}} attribute.
+        If you need to toggle an HTML element's display using JavaScript, and want to fully support Internet Explorer 7 &amp; 8, we suggest creating your own {{code ".hidden"}} CSS class instead of using the {{code "hidden"}} attribute.
     </p>
 
     <h3>Responsive Images</h3>


### PR DESCRIPTION
I've added a warning about using the HTML5 style hidden attribute in old version of Internet Explorer, namely versions 7 & 8. This pull request is a documentation fix for the [Pure.css Git issue 405](https://github.com/yahoo/pure/issues/405)