### PR TITLE
Add `pure-menu-open` CSS class to the main menu

### DIFF
--- a/views/partials/menu.handlebars
+++ b/views/partials/menu.handlebars
@@ -3,7 +3,7 @@
 </a>
 
 <div id="menu">
-    <div class="pure-menu">
+    <div class="pure-menu pure-menu-open">
         <a class="pure-menu-heading" href="{{pathTo 'home'}}">Pure</a>
 
         <ul class="pure-menu-list">


### PR DESCRIPTION
I made this pull request to fix issue #302, feel free to ignore or reject it if the new pure menus fix the problem.