### PR TITLE
KeyCDN added to the list of Alternate CDNs

### DIFF
--- a/views/pages/customize.handlebars
+++ b/views/pages/customize.handlebars
@@ -72,6 +72,12 @@
                     <td>No</td>
                 </tr>
                 <tr>
+                    <td><a href="https://www.keycdn.com/">KeyCDN</a></td>
+                    <td>//purecss.keycdn.com/pure/{{pure.version}}/pure-min.css</td>
+                    <td>Yes</td>
+                    <td>No</td>
+                </tr>
+                <tr>
                     <td><a href="http://www.osscdn.com/">OSS MaxCDN</a></td>
                     <td>//oss.maxcdn.com/libs/pure/{{pure.version}}/pure-min.css</td>
                     <td>Yes</td>


### PR DESCRIPTION
KeyCDN is happy to support purecss.io
