### PR TITLE
Tucked-vertical example: prevent hamburger menu default action

### DIFF
--- a/views/partials/menus/tucked-vertical.handlebars
+++ b/views/partials/menus/tucked-vertical.handlebars
@@ -144,6 +144,7 @@ function closeMenu() {
 
 document.getElementById('toggle').addEventListener('click', function (e) {
     toggleMenu();
+    e.preventDefault();
 });
 
 window.addEventListener(WINDOW_CHANGE_EVENT, closeMenu);


### PR DESCRIPTION
Especially important when menu becomes `position: fixed` (clicking on hamburger would always jump to the beginning of the page without this fix).
