### PR TITLE
Integrate subresource integrity for markup examples

### DIFF
--- a/config/pure.js
+++ b/config/pure.js
@@ -1,17 +1,23 @@
 'use strict';
 
-var fs   = require('fs'),
-    path = require('path');
+var crypto = require('crypto'),
+    fs     = require('fs'),
+    path   = require('path');
+
+var serveLocally = process.argv.slice(2).some(function (arg) {
+    return arg === '--pure-local';
+});
 
 var bowerPureDir = path.resolve('bower_components', 'pure'),
-    bowerPure    = require(path.join(bowerPureDir, 'bower.json'));
-
-var args = process.argv;
+    bowerPure    = require(path.join(bowerPureDir, 'bower.json')),
+    pureMin      = fs.readFileSync(path.resolve(bowerPureDir, (serveLocally ? 'build' : ''), 'pure-min.css'), 'utf-8');
 
 exports.version = bowerPure.version;
 exports.modules = ['base', 'grids', 'forms', 'buttons', 'tables', 'menus'];
 exports.local   = path.dirname(path.join(bowerPureDir, bowerPure.main));
+exports.sriHash = crypto
+                    .createHash('sha384')
+                    .update(pureMin, 'utf8')
+                    .digest('base64');
 
-exports.serveLocally = args.slice(2).some(function (arg) {
-    return arg === '--pure-local';
-});
+exports.serveLocally = serveLocally;

--- a/middleware/pure.js
+++ b/middleware/pure.js
@@ -35,6 +35,7 @@ function getPureMetadata(pure, callback) {
         pureMetadata = {
             version   : pure.version,
             modules   : pure.modules,
+            sriHash   : pure.sriHash,
             filesizes : results.filesizes,
             gridunits : results.gridunits,
             responsive: results.responsive

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -516,6 +516,12 @@ a.pure-button-primary {
     margin-left: auto;
     margin-right: auto;
 }
+.is-code-full code {
+    display: inline-block;
+    max-width: 768px;
+    margin-left: auto;
+    margin-right: auto;
+}
 
 
 /* --------------------------

--- a/views/pages/home.handlebars
+++ b/views/pages/home.handlebars
@@ -13,7 +13,7 @@
     <div class="hero-cta">
         <div class="is-code-full">
           {{#code wrap=true}}
-            <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure-min.css">
+            <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure-min.css" integrity="sha384-{{pure.sriHash}}" crossorigin="anonymous">
           {{/code}}
         </div>
 

--- a/views/pages/start.handlebars
+++ b/views/pages/start.handlebars
@@ -20,7 +20,7 @@
 
 <div class="is-code-full">
   {{#code wrap=true}}
-    <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure-min.css">
+    <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure-min.css" integrity="sha384-{{pure.sriHash}}" crossorigin="anonymous">
   {{/code}}
 </div>
 

--- a/views/partials/styles.handlebars
+++ b/views/partials/styles.handlebars
@@ -3,7 +3,7 @@
 {{#if servePureLocally}}
 <link rel="stylesheet" href="/css/pure/pure{{min}}.css">
 {{else}}
-<link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure{{min}}.css">
+<link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/pure{{min}}.css" integrity="sha384-{{pure.sriHash}}" crossorigin="anonymous">
 {{/if}}
 
 {{#if includePureGR}}


### PR DESCRIPTION
FYI @fulldecent @KrisSiegel

Resolves https://github.com/yahoo/pure/issues/601

Looks like:

<img width="1315" alt="screen shot 2016-12-17 at 10 12 09 pm" src="https://cloud.githubusercontent.com/assets/193272/21291912/ef437ef6-c4a5-11e6-9cc8-e504e0cafc62.png">
