### PR TITLE
Add button groups example

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -60,6 +60,7 @@ dd {
 
 aside {
     background: #1f8dd6; /* same color as selected state on site menu */
+    margin: 1em 0;
     padding: 0.3em 1em;
     border-radius: 3px;
     color: #fff;

--- a/views/pages/buttons.handlebars
+++ b/views/pages/buttons.handlebars
@@ -108,6 +108,30 @@
     {{> buttons/icons}}
   {{/code}}
 
+
+  {{sectionHeading "Button Groups"}}
+  <p>
+      Group multiple buttons together on a single line.
+  </p>
+
+  <aside>
+      <p>
+          For assistive technologies (i.e, screen readers) a {{code "role"}} attribute should be provided to ensure that proper meaning is conveyed. Button groups should have a {{code "role=\"group\""}}, while toolbars should have {{code "role=\"toolbar\""}}.
+      </p>
+      <p>
+          Additionally, a clear label should be provided since most assistive technologies will not announce them. The code snippet below provides an example.
+      </p>
+  </aside>
+
+{{#prefixIds "default"}}
+  {{> buttons/groups}}
+{{/prefixIds}}
+
+
+{{#code}}
+  {{> buttons/groups}}
+{{/code}}
+
 </div>
 
 {{> prevent-scroll}}

--- a/views/partials/buttons/groups.handlebars
+++ b/views/partials/buttons/groups.handlebars
@@ -1,0 +1,5 @@
+<div class="pure-button-group" role="group" aria-label="...">
+    <button class="pure-button">A Pure Button</button>
+    <button class="pure-button">A Pure Button</button>
+    <button class="pure-button pure-button-active">A Pure Button</button>
+</div>


### PR DESCRIPTION
This adds a simple button group example from the new release.

<img width="825" alt="screen shot 2017-01-05 at 9 52 51 pm" src="https://cloud.githubusercontent.com/assets/193272/21708871/5fa432cc-d391-11e6-98f8-c9aaa9ba6304.png">
