### PR TITLE
fix: mixed content warning on extend modal page

### DIFF
--- a/views/partials/extend/modal.handlebars
+++ b/views/partials/extend/modal.handlebars
@@ -53,5 +53,5 @@
     </div>
 </div>
 
-<script src="http://code.jquery.com/jquery-1.9.1.js"></script>
-<script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
+<script src="//code.jquery.com/jquery-1.9.1.js"></script>
+<script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The modal doesn't fire as the page is trying to load JQuery and
Bootstrap over http instead of https.