### PR TITLE
Fix [if gt IE 8] comment

### DIFF
--- a/views/partials/grids/combo.handlebars
+++ b/views/partials/grids/combo.handlebars
@@ -1,6 +1,6 @@
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/grids-responsive-old-ie-min.css">
 <![endif]-->
-<!--[if gt IE 8]><!-->
+<!--[if gt IE 8]>
     <link rel="stylesheet" href="https://unpkg.com/purecss@{{pure.version}}/build/grids-responsive-min.css">
-<!--<![endif]-->
+<![endif]-->


### PR DESCRIPTION
This fixes a rogue comment symbol.